### PR TITLE
Fix: FadeTransition glitch

### DIFF
--- a/Source/MonoGame.Extended/Screens/Transitions/FadeTransition.cs
+++ b/Source/MonoGame.Extended/Screens/Transitions/FadeTransition.cs
@@ -27,7 +27,7 @@ namespace MonoGame.Extended.Screens.Transitions
         public override void Draw(GameTime gameTime)
         {
             _spriteBatch.Begin(samplerState: SamplerState.PointClamp);
-            _spriteBatch.FillRectangle(_graphicsDevice.Viewport.Bounds, Color * Value);
+            _spriteBatch.FillRectangle(0, 0, _graphicsDevice.Viewport.Width, _graphicsDevice.Viewport.Height, Color * Value);
             _spriteBatch.End();
         }
     }


### PR DESCRIPTION
The FadeTransition had visual glitches when combined with a BoxingViewportAdapter. This happened because the viewport's offset was applied twice.